### PR TITLE
Prevent error when Popup triggered from Firefox

### DIFF
--- a/src/utils/PopupHandler.ts
+++ b/src/utils/PopupHandler.ts
@@ -27,6 +27,8 @@ class PopupHandler extends EventEmitter {
   }
 
   _setupTimer(): void {
+    if (!this.window) return;
+
     this.windowTimer = Number(
       setInterval(() => {
         if (this.window && this.window.closed) {


### PR DESCRIPTION
Under Firefox extension (popup html), there will be no `window.open()` handle. This condition check prevent `Uncaught TypeError: can't access dead object` error (and it loop forever, every `500ms`).