### PR TITLE
Add serverTimeOffset props in constructor args

### DIFF
--- a/src/handlers/interfaces.ts
+++ b/src/handlers/interfaces.ts
@@ -234,6 +234,12 @@ export interface CustomAuthArgs {
    */
   web3AuthClientId: string;
 
+  /**
+   * Time difference (in seconds) between server and client
+   * @defaultValue 0
+   */
+  serverTimeOffset?: number;
+
   sentry?: Sentry;
 }
 

--- a/src/login.ts
+++ b/src/login.ts
@@ -64,6 +64,7 @@ class CustomAuth {
     enableOneKey = false,
     web3AuthClientId,
     metadataUrl = "https://metadata.tor.us",
+    serverTimeOffset = 0,
   }: CustomAuthArgs) {
     if (!web3AuthClientId) throw new Error("Please provide a valid web3AuthClientId in constructor");
     if (!network) throw new Error("Please provide a valid network in constructor");
@@ -81,8 +82,9 @@ class CustomAuth {
     };
     const torus = new Torus({
       network,
-      clientId: web3AuthClientId,
       enableOneKey,
+      serverTimeOffset,
+      clientId: web3AuthClientId,
       legacyMetadataHost: metadataUrl,
     });
     Torus.setAPIKey(apiKey);


### PR DESCRIPTION
- updated `CustomAuthArgs` to include **optional** `serverTimeOffset` value (default=0)
- add `serverTimeOffset` value in `Torus.js` instantiation