### PR TITLE
add a flag to generate key with or without dkg

### DIFF
--- a/src/handlers/interfaces.ts
+++ b/src/handlers/interfaces.ts
@@ -243,6 +243,13 @@ export interface CustomAuthArgs {
   sentry?: Sentry;
 
   keyType?: KeyType;
+
+  /**
+   * Set this flag to false to generate keys on client side
+   * by default keys are generated on using dkg protocol on a distributed network
+   * @defaultValue undefined
+   */
+  useDkg?: boolean;
 }
 
 export interface InitParams {

--- a/src/login.ts
+++ b/src/login.ts
@@ -39,6 +39,7 @@ class CustomAuth {
     uxMode: UX_MODE_TYPE;
     locationReplaceOnRedirect: boolean;
     popupFeatures: string;
+    useDkg?: boolean;
   };
 
   torus: Torus;
@@ -63,6 +64,7 @@ class CustomAuth {
     sentry,
     enableOneKey = false,
     web3AuthClientId,
+    useDkg,
     metadataUrl = "https://metadata.tor.us",
     keyType = "secp256k1",
     serverTimeOffset = 0,
@@ -80,6 +82,7 @@ class CustomAuth {
       uxMode,
       locationReplaceOnRedirect,
       popupFeatures,
+      useDkg,
     };
     const torus = new Torus({
       network,
@@ -382,6 +385,7 @@ class CustomAuth {
           extraParams: {
             ...additionalParams,
           },
+          useDkg: this.config.useDkg,
         });
       }
     );


### PR DESCRIPTION
Add a flag to generate key with or without dkg 
## Motivation and Context
This allows applications to generate keys without dkg, its useful for apps who are using customAuth sdk on backend to generate keys on more scalable way.


Jira Link:


## Description
<!--- Describe your changes in detail -->


## How has this been tested?
<!--- Tested manually with example -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project. (run lint)
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
